### PR TITLE
Make timeout time configurable from the control port

### DIFF
--- a/vncap/control.py
+++ b/vncap/control.py
@@ -32,6 +32,7 @@ class ControlProtocol(LineReceiver):
             ws = d.get("ws", False)
             tls = d.get("tls", False)
             client_opts = d.get("client", {})
+            timeout_secs = d.get("timeout", 30)
 
             # Allocate the source port.
             sport = self.factory.allocate_port(sport)
@@ -52,7 +53,7 @@ class ControlProtocol(LineReceiver):
                 log.msg("Timed out connection on port %d" % sport)
                 listening.stopListening()
                 self.factory.free_port(sport)
-            reactor.callLater(30, timeout)
+            reactor.callLater(timeout_secs, timeout)
 
             log.msg("New forwarder (%d->%s:%d)" % (sport, host, dport))
             self.sendLine("%d" % sport)


### PR DESCRIPTION
This change is backwards compatible, if the "timeout" value is not submitted to the control port then the default value of 30s will be used instead. This new option can be used to lower the time a malicious actor has to bruteforce the password.